### PR TITLE
Added support for advanced logic in Advanced Toggle

### DIFF
--- a/VoiceMeeter/VMManager.cs
+++ b/VoiceMeeter/VMManager.cs
@@ -75,6 +75,11 @@ namespace VoiceMeeter
             return client.GetParam(paramName).ToString("0.##");
         }
 
+        public string GetParamString(string paramName)
+        {
+            return client.GetParamString(paramName);
+        }
+
         public void SetParam(string paramName, float value)
         {
             client.SetParam(paramName, value);

--- a/VoiceMeeter/VoiceMeeterWrapper/VmClient.cs
+++ b/VoiceMeeter/VoiceMeeterWrapper/VmClient.cs
@@ -1,5 +1,7 @@
 ﻿using Microsoft.Win32;
 using System;
+using System.Text;
+using BarRaider.SdTools;
 
 namespace VoiceMeeterWrapper
 {
@@ -31,6 +33,15 @@ namespace VoiceMeeterWrapper
             float output = -1;
             VoiceMeeterRemote.GetParameter(n, ref output);
             return output;
+        }
+
+        public string GetParamString( string n)
+        {
+            //string output = "";
+            StringBuilder output = new StringBuilder(512);
+            VoiceMeeterRemote.GetParameter(n, output);
+
+            return output.ToString();
         }
 
         public void SetParam(string n, float v)

--- a/VoiceMeeter/VoiceMeeterWrapper/VoiceMeeterRemote.cs
+++ b/VoiceMeeter/VoiceMeeterWrapper/VoiceMeeterRemote.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Runtime.InteropServices;
+using System.Text;
 
 namespace VoiceMeeterWrapper
 {
@@ -20,7 +21,7 @@ namespace VoiceMeeterWrapper
         public static extern int GetParameter(string szParamName, ref float value);
 
         [DllImport("VoicemeeterRemote.dll", EntryPoint = "VBVMR_GetParameterStringA")]
-        public static extern int GetParameter(string szParamName, ref string value);
+        public static extern int GetParameter(string szParamName, StringBuilder value);
 
         [DllImport("VoicemeeterRemote.dll", EntryPoint = "VBVMR_IsParametersDirty")]
         public static extern int IsParametersDirty();


### PR DESCRIPTION
I have added support for advance logic detection in the Advance Toggle Mode1 Check. Two supported operators have been added to the list `==` and `!=`

You can use this for checking the input names of strips or buses.

Example usage:
`ADV Bus[0].device.name == "Realtek Speakers"`

You must prefix your check with `ADV` with the VM parameter on the left, and the string comparison on the right.