### PR TITLE
Include bus parameters on modify action

### DIFF
--- a/VoiceMeeter/Actions/VMModifyAction.cs
+++ b/VoiceMeeter/Actions/VMModifyAction.cs
@@ -29,7 +29,14 @@ namespace VoiceMeeter
             eqgain2 = 12,
             eqgain3 = 13,
             mc      = 14,
-            audibility = 15
+            audibility = 15,
+            a1 = 16,
+            a2 = 17,
+            a3 = 18,
+            a4 = 19,
+            b1 = 20,
+            b2 = 21,
+            b3 = 22
         }
 
         private class PluginSettings


### PR DESCRIPTION
A friend uses this plugin and wants to toggle the `A1` button on the strip, which can be used in her case to toggle whether she can hear herself. Currently this parameter is not included.